### PR TITLE
implement start minimized to tray option

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -83,6 +83,12 @@ ipcMain.on('pref-change-zoom', (e, zoom) => {
     store.set('prefs', prefs);
 });
 
+ipcMain.on('pref-change-start-minimized', (e, startMinimized) => {
+    const prefs = store.get('prefs') || {};
+    prefs.startMinimized = startMinimized;
+    store.set('prefs', prefs);
+});
+
 // Show window when clicking on macosx dock icon
 app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
@@ -151,6 +157,11 @@ function createWindow() {
     });
 
     win.on('resize', saveWindowSize);
+
+    // Hide if startMinimized is true in prefs
+    if (prefs.startMinimized) {
+        win.hide();
+    }
 
     return win;
 }

--- a/src/pages/customize.css
+++ b/src/pages/customize.css
@@ -27,3 +27,11 @@
     background-color:  rgb(224, 242, 241);
 
 }
+
+input[type=checkbox] {
+    width: 20px;
+    height: 20px;
+    display: inline-block;
+    position: relative;
+    top: 5px;
+}

--- a/src/pages/customize.html
+++ b/src/pages/customize.html
@@ -22,11 +22,18 @@
                         <option value="minty">Minty</option>
                         <option value="cerulean">Cerulean</option>
                     </select>
-                  </div>
-                  <div class="form-group">
+                </div>
+                <div class="form-group">
                     <label for="zoom">Zoom (%)</label>
                     <input class="form-control" id="zoom" value="100" />
-                  </div>
+                </div>
+                <div class="form-group">
+                    <label for="theme">Start minimized to tray</label>
+                    <select class="form-control" id="start-minimized">
+                        <option value="false">No</option>
+                        <option value="true">Yes</option>
+                    </select>
+                </div>
             </div>
         </div>
         <script src="customize.js" type="text/javascript"></script>

--- a/src/pages/customize.html
+++ b/src/pages/customize.html
@@ -28,11 +28,8 @@
                     <input class="form-control" id="zoom" value="100" />
                 </div>
                 <div class="form-group">
-                    <label for="theme">Start minimized to tray</label>
-                    <select class="form-control" id="start-minimized">
-                        <option value="false">No</option>
-                        <option value="true">Yes</option>
-                    </select>
+                    <label for="start-minimized">Start minimized to tray?</label>
+                    <input type="checkbox" class="form-control" id="start-minimized">
                 </div>
             </div>
         </div>

--- a/src/pages/customize.js
+++ b/src/pages/customize.js
@@ -21,5 +21,13 @@
          ipcRenderer.send('pref-change-zoom', zoom);
     });
     zoomSetting.value = currentZoom;
+
+    const currentStartMinimized = prefs.startMinimized || false;
+    const minimizedSetting = document.getElementById("start-minimized");
+    minimizedSetting.addEventListener('blur', (e) => {
+         const val = e.target.value;
+         ipcRenderer.send('pref-change-start-minimized', val == 'true');
+    });
+    minimizedSetting.value = currentStartMinimized;
         
 })();

--- a/src/pages/customize.js
+++ b/src/pages/customize.js
@@ -24,9 +24,9 @@
 
     const currentStartMinimized = prefs.startMinimized || false;
     const minimizedSetting = document.getElementById("start-minimized");
-    minimizedSetting.addEventListener('blur', (e) => {
-         const val = e.target.value;
-         ipcRenderer.send('pref-change-start-minimized', val == 'true');
+    minimizedSetting.addEventListener('change', (e) => {
+         const val = e.target.checked;
+         ipcRenderer.send('pref-change-start-minimized', val);
     });
     minimizedSetting.value = currentStartMinimized;
         


### PR DESCRIPTION
This implements an option to start the application minimized to tray. Useful for setups (like my own) where the application automatically opens on system startup.