### PR TITLE
Multi-User Support

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -135,8 +135,15 @@ function createWindow() {
     badgeGenerator = new BadgeGenerator(win);
 
     win.webContents.on('new-window', function(e, url) {
-        e.preventDefault();
-        shell.openExternal(url);
+        // If the user has clicked the "Add another account" link under their user icon, allow this to
+        // be handled within our application so that the addition/authentication takes place within our
+        // application cache.  Otherwise, for all other URLs, have the system open them using their default
+        // type handler.  The main reason we do this is to ensure that URLs are opened in the user's
+        // browser, where they are likely already signed into services that need authentication.
+        if (!url.startsWith('https://accounts.google.com/AddSession?')) {
+            e.preventDefault();
+            shell.openExternal(url);
+        }
     });
 
 	win.on('close', function (event) {

--- a/src/main.js
+++ b/src/main.js
@@ -115,7 +115,7 @@ function createWindow() {
         }
     })
     win.removeMenu();
-    win.loadURL('https://voice.google.com', { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:82.0) Gecko/20100101 Firefox/82.0' });
+    loadGoogleVoiceInMainWindow();
     // win.webContents.openDevTools();
 
     win.webContents.on('did-finish-load', () => {
@@ -135,13 +135,19 @@ function createWindow() {
     badgeGenerator = new BadgeGenerator(win);
 
     win.webContents.on('new-window', function(e, url) {
-        // If the user has clicked the "Add another account" link under their user icon, allow this to
-        // be handled within our application so that the addition/authentication takes place within our
-        // application cache.  Otherwise, for all other URLs, have the system open them using their default
-        // type handler.  The main reason we do this is to ensure that URLs are opened in the user's
-        // browser, where they are likely already signed into services that need authentication.
-        if (!url.startsWith('https://accounts.google.com/AddSession?')) {
-            e.preventDefault();
+        e.preventDefault(); // Cancel the request to open the target URL in a new window
+
+        // If the target URL is a Google Voice URL, have our main window navigate to it instead of opening
+        // it in a new window.  This supports the ability to add additional accounts and switch between
+        // them on-demand.  Otherwise, for all other URLs, have the system open them using the default type
+        // handler.  This is done to force URLs to open in the user's browser, where they are likely already
+        // signed into services that need authentication (e.g. Spotify).  Note that if the user ever gets
+        // stuck navigated somewhere that isn't the main Google Voice page, they can always use the "Reload"
+        // item in the notification area icon context menu to get back to the Google Voice home page.
+        if ((url.startsWith('https://voice.google.com') || url.startsWith('https://accounts.google.com'))) {
+            win && win.loadURL(url);
+        }
+        else {
             shell.openExternal(url);
         }
     });
@@ -160,6 +166,12 @@ function createWindow() {
     win.on('resize', saveWindowSize);
 
     return win;
+}
+
+// Loads Google Voice in the main application window, identifying this application as Firefox running on
+// a Mac.  During the load, Google Voice itself takes care of asking the user to log in when necessary.
+function loadGoogleVoiceInMainWindow() {
+    win && win.loadURL('https://voice.google.com', {userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:82.0) Gecko/20100101 Firefox/82.0'});
 }
 
 function updateNotifications(app) {
@@ -238,6 +250,11 @@ function createTray(iconPath, tipText) {
         {
             label: 'Open', click: function () {
                 win && win.show();
+            }
+        },
+        {
+            label: 'Refresh', click: function () {
+                loadGoogleVoiceInMainWindow();
             }
         },
         {

--- a/src/utils/menuInjector.js
+++ b/src/utils/menuInjector.js
@@ -10,7 +10,7 @@ module.exports = class Injector {
 
     inject() {
         this.win.webContents.executeJavaScript(`document.querySelectorAll('[gv-test-id="sidenav-spam"]').length`).then(len => {
-            console.log('Attemping to inject menu');
+            console.log('Attempting to inject menu');
             if (len > 0) {
                 // Inject menu
                 this.win.webContents.executeJavaScript(`


### PR DESCRIPTION
## Changes
#### Multi-User Support
This change adds support for switching between multiple Google Voice accounts under the user icon in the top-right corner of the Google Voice home page.
![image](https://user-images.githubusercontent.com/1672416/132960385-c38e806b-04d3-4a44-8cad-3f80098b9974.png)


Today, the application doesn't allow users to add multiple Google Voice accounts.  This occurs because the application intercepts "new-window" events and opens the target URL using `shell.openExternal()`.  The result is that when the user clicks the _"Add another account"_ link in Google Voice, they're taken to a web page in their external browser to complete the action.  This adds the new user in the browser context, but does not add it in the Electron application context, where it's actually needed.

To fix this, we grant an exception to the following two URLs:
- `voice.google.com`, which should represent all Google Voice UI that should be rendered within our application, and
- `accounts.google.com`, which Google Voice attempts to load in a new window when the user clicks the "Add another account" link under their user icon.

Rather than open any of the above URLs in a new window, we have our main window navigate to them instead.  The result is that the entire "Add another account" flow now takes place within the main window.  Additionally, when switching between accounts, each account is loaded in the main window, rather than in a secondary window, which is what Google Voice does when used in a regular browser.  In a future change, it would be possible to update the application such that additional accounts are opened in their own windows, and each account/window is given its own icon in the notification area.  But for this initial solution, the desired behaviour is to only allow the user to use one account at a time.

#### "Reload" item in notification area context menu
For the two URLs mentioned above, we consider any URL starting with the noted prefix to be _that_ URL (i.e. we use `String.startsWith()` for comparison purposes.  In testing multi-user support, I have not yet found any scenario where this causes a URL to be navigated to which absolutely must be launched in a new window instead.  However, in the even that this changelist ever does result in the user being permanently navigated away from the Google Voice home page without any way to get back, we also add a `**Reload**` item to the notification area context menu.  When clicked, the main window simply reloads Google Voice.

This new menu item also serves as a convenient way of getting users unstuck when they encounter the infamous "white screen" bug, where the main application window becomes a blank canvas after returning to the application after a period of inactivity.

## How Tested?
- Changes have been tested on Windows 10.
- Logged into main account from scratch.
- Added a second account under the user icon in the top-right corner.
- Confirmed that "add user" flow takes place entirely within the main window.
- Confirmed that multiple accounts can be successfully switched between.
- Confirmed that notification count (including rendered red dot on notification area icon) successfully updates appropriately when switching between accounts.
- Confirmed that clicking the new "Reload" context menu item causes the main window to re-navigate to Google Voice.
- Confirmed that notification area icon also updates appropriately when "Reload" menu item is clicked while main window is closed.