### PR TITLE
Display Application Name and Icon in Toasts

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,20 @@
+/**********************************************************************************************************************
+ * This module contains constants that are meant to be used throughout the entire application.  Each constant is
+ * defined using the define() function which ensures that it remains read-only when this module is consumed.
+ **********************************************************************************************************************/
+
+function define(name, value) {
+    Object.defineProperty(exports, name, {
+        value:      value,
+        enumerable: true
+    });
+}
+
+// Strings
+define('APPLICATION_NAME', 'Voice Desktop'); // Application name
+
+// Images
+define('APPLICATION_ICON_Large',              '1024px-Google_Voice_icon_(2020).png');     // Application icon (large)  --sufficient size for MacOS Doc
+define('APPLICATION_ICON_Medium',             '64px-Google_Voice_icon_(2020).png');       // Application icon (medium) --sufficient size for Windows Taskbar
+define('APPLICATION_ICON_Small',              'tray-Google_Voice_icon_(2020).png');       // Application icon (small)  --sufficient size for system notification area
+define('APPLICATION_ICON_SmallWithIndicator', 'tray-dirty-Google_Voice_icon_(2020).png'); // Application icon (small, with "notifications" indicator)

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,20 +1,23 @@
 /**********************************************************************************************************************
- * This module contains constants that are meant to be used throughout the entire application.  Each constant is
- * defined using the define() function which ensures that it remains read-only when this module is consumed.
+ * This module contains constants that are meant to be used throughout the entire application.
  **********************************************************************************************************************/
 
-function define(name, value) {
-    Object.defineProperty(exports, name, {
-        value:      value,
-        enumerable: true
-    });
-}
-
 // Strings
-define('APPLICATION_NAME', 'Voice Desktop'); // Application name
+const APPLICATION_NAME = 'Voice Desktop';
 
 // Images
-define('APPLICATION_ICON_Large',              '1024px-Google_Voice_icon_(2020).png');     // Application icon (large)  --sufficient size for MacOS Doc
-define('APPLICATION_ICON_Medium',             '64px-Google_Voice_icon_(2020).png');       // Application icon (medium) --sufficient size for Windows Taskbar
-define('APPLICATION_ICON_Small',              'tray-Google_Voice_icon_(2020).png');       // Application icon (small)  --sufficient size for system notification area
-define('APPLICATION_ICON_SmallWithIndicator', 'tray-dirty-Google_Voice_icon_(2020).png'); // Application icon (small, with "notifications" indicator)
+const APPLICATION_ICON_LARGE                = '1024px-Google_Voice_icon_(2020).png';
+const APPLICATION_ICON_MEDIUM               = '64px-Google_Voice_icon_(2020).png';
+const APPLICATION_ICON_SMALL                = 'tray-Google_Voice_icon_(2020).png';
+const APPLICATION_ICON_SMALL_WITH_INDICATOR = 'tray-dirty-Google_Voice_icon_(2020).png';
+
+module.exports = {
+    // Strings
+    APPLICATION_NAME, // Application name (displayed in various places)
+
+    // Images
+    APPLICATION_ICON_LARGE,               // Main application icon (large)  --sufficient size for MacOS Doc
+    APPLICATION_ICON_MEDIUM,              // Main application icon (medium) --sufficient size for Windows Taskbar
+    APPLICATION_ICON_SMALL,               // Main application icon (small)  --sufficient size for system notification area
+    APPLICATION_ICON_SMALL_WITH_INDICATOR // Main application icon (small, with "notifications" indicator)
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 // Requires
 const { app, nativeImage, BrowserWindow, Tray, Menu, ipcMain, ipcRenderer, BrowserView, shell, powerMonitor } = require('electron');
+const constants = require("./constants");
 const contextMenu = require('electron-context-menu');
 const BadgeGenerator = require('./badge_generator');
 const path = require('path');
@@ -12,13 +13,10 @@ const Url = require('url');
 const store = new Store();
 const appPath = app.getAppPath();
 const REFRESH_RATE = 1000; // 1 seconds
-
-const icon = path.join(appPath, 'images', '64px-Google_Voice_icon_(2020).png');
-const iconTray = path.join(appPath, 'images', 'tray-Google_Voice_icon_(2020).png');
-const iconTrayDirty = path.join(appPath, 'images', 'tray-dirty-Google_Voice_icon_(2020).png');
-const dockIcon = nativeImage.createFromPath(
-    path.join(appPath, 'images', '1024px-Google_Voice_icon_(2020).png')
-);
+const icon = path.join(appPath, 'images', constants.APPLICATION_ICON_Medium);
+const iconTray = path.join(appPath, 'images', constants.APPLICATION_ICON_Small);
+const iconTrayDirty = path.join(appPath, 'images', constants.APPLICATION_ICON_SmallWithIndicator);
+const dockIcon = nativeImage.createFromPath(path.join(appPath, 'images', constants.APPLICATION_ICON_Large));
 const DEFAULT_WIDTH = 1200;
 const DEFAULT_HEIGHT = 900;
 
@@ -50,6 +48,13 @@ contextMenu({
     showSaveImage: true,
     showInspectElement: true
 });
+
+// If we're running on Windows, set our Application User Model ID to our application name.
+// This will be displayed in all system Toasts that get generated to display notifications
+// to the user.  If we don't do this, "electron.app.Electron" will be displayed instead.
+if (process.platform === 'win32'){
+    app.setAppUserModelId(constants.APPLICATION_NAME);
+}
 
 // Setup notification shim to focus window
 ipcMain.on('notification-clicked', () => {
@@ -99,6 +104,11 @@ ipcMain.on('pref-change-start-minimized', (e, startMinimized) => {
     const prefs = store.get('prefs') || {};
     prefs.startMinimized = startMinimized;
     store.set('prefs', prefs);
+});
+
+// Set up an IPC handler that can be used by renderer processes to retrieve the execution path of this application.
+ipcMain.handle('get-appPath', async (event, ...args) => {
+    return app.getAppPath();
 });
 
 // Show window when clicking on macosx dock icon

--- a/src/main.js
+++ b/src/main.js
@@ -13,10 +13,10 @@ const Url = require('url');
 const store = new Store();
 const appPath = app.getAppPath();
 const REFRESH_RATE = 1000; // 1 seconds
-const icon = path.join(appPath, 'images', constants.APPLICATION_ICON_Medium);
-const iconTray = path.join(appPath, 'images', constants.APPLICATION_ICON_Small);
-const iconTrayDirty = path.join(appPath, 'images', constants.APPLICATION_ICON_SmallWithIndicator);
-const dockIcon = nativeImage.createFromPath(path.join(appPath, 'images', constants.APPLICATION_ICON_Large));
+const icon = path.join(appPath, 'images', constants.APPLICATION_ICON_MEDIUM);
+const iconTray = path.join(appPath, 'images', constants.APPLICATION_ICON_SMALL);
+const iconTrayDirty = path.join(appPath, 'images', constants.APPLICATION_ICON_SMALL_WITH_INDICATOR);
+const dockIcon = nativeImage.createFromPath(path.join(appPath, 'images', constants.APPLICATION_ICON_LARGE));
 const DEFAULT_WIDTH = 1200;
 const DEFAULT_HEIGHT = 900;
 

--- a/src/main.js
+++ b/src/main.js
@@ -158,7 +158,7 @@ function createWindow() {
     if (tray) {
         tray.destroy;
     }
-    tray = createTray(iconTray, 'Google Voice Tray');
+    tray = createTray(iconTray, constants.APPLICATION_NAME);
 
     badgeGenerator = new BadgeGenerator(win);
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,4 +1,15 @@
+/**********************************************************************************************************************
+ * Preload script for the main application window.  Contains all code
+ * that needs to execute before the window's web content begins loading.
+ **********************************************************************************************************************/
 
-const { notificationShim } = require('./utils/notificationShim');
+(async() => {
+    // Get this application's execution path.
+    const {ipcRenderer} = require("electron");
+    const appPath = await ipcRenderer.invoke("get-appPath");
 
-notificationShim();
+    // Modify JavaScript's "Notification" class such that all notifications that get generated will have a
+    // click handler attached to them which fires a "notification-clicked" event back at the main process.
+    const {notificationShim} = require("./utils/notificationShim");
+    notificationShim(appPath);
+})();

--- a/src/utils/notificationShim.js
+++ b/src/utils/notificationShim.js
@@ -1,13 +1,26 @@
+/**********************************************************************************************************************
+ * This module's main purpose is to automatically attach a "click" handler onto all Notifications that get
+ * created using JavaScript's "Notification" class.  When the attached handler is invoked (i.e. when any
+ * Notification gets clicked by the user), a "notification-clicked" event gets sent to the main application
+ * process, letting it know that the user has activated a notification.  Secondary to that, Notifications
+ * that don't have an icon assigned to them are also modified to display this application's icon.
+ **********************************************************************************************************************/
+
 const { ipcRenderer } = require('electron');
+const constants = require('../constants.js');
+const path = require('path');
 
-module.exports.notificationShim = function() {
-    // Shim out notification so we can override on click
+module.exports.notificationShim = function(appPath) {
     const OldNotification = Notification;
-
-    // Notification shim to send a click event to the main process so we can unhide the window (if hidden)
     Notification = function (title, options) {
+        // If the specified options don't include an icon for the notification, set the icon to our application icon.
+        if (!options)      { options = {}; }
+        if (!options.icon) { options.icon = path.join(appPath, 'images', constants.APPLICATION_ICON_Medium); }
+                
+        // Create a normal Notification instance using the specified parameters.
         const oldNotification = new OldNotification(title, options);
-        
+                
+        // Automatically add a click handler, which notifies the main process when a click occurs.
         oldNotification.addEventListener('click', () => {
             console.log('clicked');
             ipcRenderer.send('notification-clicked', {});

--- a/src/utils/notificationShim.js
+++ b/src/utils/notificationShim.js
@@ -15,7 +15,7 @@ module.exports.notificationShim = function(appPath) {
     Notification = function (title, options) {
         // If the specified options don't include an icon for the notification, set the icon to our application icon.
         if (!options)      { options = {}; }
-        if (!options.icon) { options.icon = path.join(appPath, 'images', constants.APPLICATION_ICON_Medium); }
+        if (!options.icon) { options.icon = path.join(appPath, 'images', constants.APPLICATION_ICON_MEDIUM); }
                 
         // Create a normal Notification instance using the specified parameters.
         const oldNotification = new OldNotification(title, options);


### PR DESCRIPTION
### Changes
In this commit we update the application so that Windows Toasts that get generated always contain the application name and icon.  To do this, we tweak the application's existing `notificationShim` module.  Whenever a notification is generated that doesn't have an icon, we set the icon to be the application icon.

During application startup, we also make a call to `app.setAppUserModelId()`, setting our application name.  This ensures that "**Google Voice**" shows up as the sender of the Toast instead of "**electron.app.Electron**", which is what shows up today.

![image](https://user-images.githubusercontent.com/1672416/133880111-f9f025d8-04d1-4628-b7c7-59ece7d18e56.png)

- In this change we also introduce a new `constants` module for sharing application constants between files.
- We also update the notification area icon's tooltip text so that it matches the application name.
![image](https://user-images.githubusercontent.com/1672416/133880646-331a9297-5f1c-4858-9bbe-aa7a65e0dba4.png)


### Testing
- Tested on Windows.
- Tested Toast generated due to incoming text message.
- Tested Toast generated due to incoming phone call.