### PR TITLE
Fix white screen bug / Remove window flicker when starting hidden / Add "start automatically" setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
  "author": "jllankfo@ncsu.edu",
  "license": "ISC",
  "dependencies": {
+  "auto-launch": "^5.0.5",
   "electron-context-menu": "^3.1.1",
   "electron-store": "^8.0.0",
   "sass": "^1.32.8"

--- a/src/main.js
+++ b/src/main.js
@@ -435,28 +435,28 @@ function isWindows() {return (process.platform === 'win32');}
 // ====================================================================================================================
 
 // Returns the execution path of this application.
-ipcMain.handle('get-appPath', (event) => {
+ipcMain.handle('get-appPath', () => {
     return app.getAppPath();
 });
 
 // Returns the platform that this application is running on.
-ipcMain.handle('get-platform', (event) => {
+ipcMain.handle('get-platform', () => {
     return process.platform;
 });
 
 // Returns an object representing the user's current settings store.
-ipcMain.handle('get-user-prefs', (event) => {
+ipcMain.handle('get-user-prefs', () => {
     return store.get('prefs') || {};
 });
 
 // Returns a bool indicating whether this application is registered to start automatically at logon.
-ipcMain.handle('get-start-automatically', async (event) => {
+ipcMain.handle('get-start-automatically', async () => {
     let autoLaunch = new AutoLaunch({name: constants.APPLICATION_NAME, path: app.getPath('exe')})
     return await autoLaunch.isEnabled();
 });
 
 // Returns the current zoom level of this this application's main window.
-ipcMain.handle('get-zoom-level', (event) => {
+ipcMain.handle('get-zoom-level', () => {
     return win.webContents.getZoomLevel();
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -278,9 +278,9 @@ function updateNotifications(app) {
     // has become empty.  If it has, then we automatically reload Google Voice for the
     // user.  This seems to eliminate the problem entirely, without any adverse effects,
     // as once we detect an empty body, the application is already in a non-working state.
-    win.webContents.executeJavaScript("document.getElementsByTagName('body')[0].innerText.trim()").then(
+    win.webContents.executeJavaScript("document.querySelector('body').childNodes.length").then(
         (result) => {
-            if (result == ''){
+            if (result === 0){
                 loadGoogleVoice();
             }
         })

--- a/src/pages/customize.html
+++ b/src/pages/customize.html
@@ -36,19 +36,25 @@
                 <!--Options-->
                 <div class="form-group">
                     <label class="font-weight-bold">Options</label>
-                    
+
                     <!--"Show menu bar" checkbox (Windows/Linux only, will get hidden for Mac)-->
                     <div class="form-check" id="show-menubar-div">
                         <input class="form-check-input" type="checkbox" id="show-menubar">
                         <label class="form-check-label" for="show-menubar">Show menu bar</label>
                     </div>
 
+                    <!--"Start automatically" checkbox-->
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="start-automatically">
+                        <label class="form-check-label" for="start-automatically">Start application automatically at logon</label>
+                    </div>
+
                     <!--"Start minimized" checkbox-->
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="start-minimized">
-                        <label class="form-check-label" for="start-minimized">Start minimized to tray</label>
+                        <label class="form-check-label" for="start-minimized">Start application minimized to tray</label>
                     </div>
-                    
+
                     <!--"Exit on close" checkbox-->
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="exit-on-close">
@@ -56,7 +62,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <!--Place window buttons in this div.-->
             <div id="second-row">
                 <!--"Close" button-->

--- a/src/pages/customize.js
+++ b/src/pages/customize.js
@@ -55,6 +55,15 @@
         });
     }
 
+    // Set the "start automatically" checkbox based on the user's currently selected
+    // preference.  Notify the main process whenever the preference changes.
+    const startAutomatically = document.getElementById('start-automatically');
+    startAutomatically.checked = await ipcRenderer.invoke('get-start-automatically');
+    startAutomatically.addEventListener('change', (e) => {
+        const checked = e.target.checked;
+        ipcRenderer.send('pref-change-start-automatically', checked);
+    });
+
     // Set the "start minimized" checkbox based on the user's currently selected
     // startup mode.  Notify the main process whenever the user changes the mode.
     const minimizedSetting = document.getElementById('start-minimized');


### PR DESCRIPTION
In this commit we make the following changes:

## Fix "White Screen of Death"
An issue that many users experience is that after an indeterminate period of time, the main application window becomes a blank white screen.  When this happens, the application stops functioning because there is no content to be checked for new notifications anymore.  As far as we can tell, this is a bug in Electron, not a bug in this application or Google Voice.  To work around this issue, we update our "check for new notifications" interval to be every 3 seconds instead of 1 and add an extra check to see whether the content of the window has become "blank" (the white screen of death).  When we detect this state, we automatically reload Google Voice.  Since the application is already broken once we detect this state, forcing a reload should have no adverse effect (data loss, for example).

## Remove window flicker when starting hidden
Currently, when the "start minimized" setting is enabled, the main application window flickers on screen briefly before it gets hidden.  We fix this by reversing our window creation logic.  We make the window hidden initially, and then show it only if the "start minimized" setting hasn't been turned on (it's always off by default).

## Add "start automatically" setting
Finally, as a companion change to the fixing of the "white screen of death" bug, we make one additional change that hopefully finalizes the user's ability to never miss a notification when using this application.  In the settings dialog, we add a new "Start automatically at logon" setting.

![image](https://user-images.githubusercontent.com/1672416/148663415-ee6aef06-93ed-4b66-9b39-86ef69732916.png)